### PR TITLE
Add unit tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Through this process I learned how valuable up‑front planning can be and how t
    python main.py
    ```
 
+## Running Tests
+To execute the unit tests use Python's built in `unittest` runner:
+
+```bash
+python -m unittest discover -v
+```
+
+The `-v` flag shows a line for every test and clearly reports any failures with
+the file and line number where the assertion failed.
+
 ## Codebase Structure
 - `main.py` – Entry point. Provides the command line loop.
 - `UIManager.py` – Handles user interactions and coordinates actions.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,59 @@
+import os
+import tempfile
+import unittest
+
+from ExpenseClass import Expense
+from StateManager import StateManager
+from CSVService import CSVService
+from UIManager import UIManager
+
+class TestExpense(unittest.TestCase):
+    def test_get_key(self):
+        exp = Expense({'date': '2024-01-01', 'category': 'Food', 'amount': '10', 'description': 'Lunch'})
+        self.assertEqual(exp.get_key('amount'), '10')
+        self.assertIsNone(exp.get_key('nonexistent'))
+
+class TestStateManager(unittest.TestCase):
+    def test_add_expense_and_budget(self):
+        sm = StateManager()
+        sm.set_budget(5)
+        sm.add_expense({'date': '2024-01-01', 'category': 'Food', 'amount': '10', 'description': 'Lunch'})
+        self.assertEqual(len(sm.get_expenses()), 1)
+        self.assertAlmostEqual(sm.get_total_spent(), 10.0)
+        self.assertFalse(sm.check_budget())
+
+class TestCSVService(unittest.TestCase):
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.service = CSVService()
+        self.service._csvFilePath = self.temp_file.name
+
+    def tearDown(self):
+        try:
+            os.unlink(self.temp_file.name)
+        except FileNotFoundError:
+            pass
+
+    def test_convert_and_io(self):
+        expenses = [Expense({'date': '2024-01-01', 'category': 'Food', 'amount': '12.34', 'description': 'Lunch'})]
+        csv_str = self.service.convert_listdict_to_csv(expenses)
+        self.assertIn('2024-01-01', csv_str)
+
+        # Write and read back
+        self.service.write_csv(expenses)
+        self.service.read_csv()
+        result = self.service._asyncQueue.get_nowait()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].get_key('amount'), '12.34')
+
+class TestUIManager(unittest.TestCase):
+    def test_validate_number_input(self):
+        ui = UIManager()
+        ui.validate_number_input('10.55')  # should not raise
+        with self.assertRaises(ValueError):
+            ui.validate_number_input('-1')
+        with self.assertRaises(ValueError):
+            ui.validate_number_input('1.999')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new unit tests covering Expense, StateManager, CSVService, and UIManager
- document how to run tests in README

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_684229eaceac83298e19860992903c68